### PR TITLE
fix(remotion): prevent fallback to mock data in VerticalStill

### DIFF
--- a/src/lib/schemas/stats.ts
+++ b/src/lib/schemas/stats.ts
@@ -25,14 +25,14 @@ export const mainSchema = z.object({
   performancesProps: myPerformancesSchema,
   favouriteCharactersProps: favouriteCharactersSchema,
   worstMatchupsProps: worstMatchupsSchema,
-  highestUpsetProps: highestUpsetSchema.optional(),
-  rivalryProps: rivalrySchema.optional(),
+  highestUpsetProps: highestUpsetSchema.optional().nullable(),
+  rivalryProps: rivalrySchema.optional().nullable(),
   game5WarriorProps: game5WarriorSchema,
   cleanSweepProps: cleanSweepSchema,
   dqProps: dqSchema,
   gauntletProps: theGauntletSchema,
   dayOfWeekActivityProps: dayOfWeekActivitySchema,
-  busterRunProps: busterRunSchema.optional(),
+  busterRunProps: busterRunSchema.optional().nullable(),
   gameStats: gameStatsSchema,
   setsPlayed: z.number()
 });

--- a/src/routes/(app)/user/[userId]/+page.svelte
+++ b/src/routes/(app)/user/[userId]/+page.svelte
@@ -156,7 +156,7 @@
     favouriteCharactersProps: {
       characters: stats.mostPlayedCharactersByPlayer
     },
-    highestUpsetProps: stats.highestUpset,
+    highestUpsetProps: stats.highestUpset ?? null,
     game5WarriorProps: {
       totalSets: stats.sets.lastgames.count,
       wins: stats.sets.lastgames.winCount,
@@ -176,8 +176,8 @@
     dayOfWeekActivityProps: {
       activity: stats.dayOfWeekActivity
     },
-    busterRunProps: stats.worstPerformance,
-    rivalryProps: stats.rivalry,
+    busterRunProps: stats.worstPerformance ?? null,
+    rivalryProps: stats.rivalry ?? null,
     gameStats: stats.gameStats,
     setsPlayed: stats.sets.total
   }}


### PR DESCRIPTION
- Update stats schema to allow nullable optional props
- Explicitly pass null instead of undefined in +page.svelte to override defaultProps

## Notes

- This may require to redeploy the remotion bundle
- Regenerate image recap for Top 20